### PR TITLE
bug fix - Highlighted boxes animation restarts

### DIFF
--- a/js/highlighted_boxes.js
+++ b/js/highlighted_boxes.js
@@ -115,6 +115,9 @@
     let particles_count = 30;
 
     function set_target_to(box) {
+        if(target_box!==null){
+            return;
+        }
         target_box = box;
         let path = create_path_around(target_box, 10);
         particles = [];


### PR DESCRIPTION
it used to restart animation, when mouse used to hover over the box, now it is fixed.
.
it gives a silk smooth animation right now